### PR TITLE
Feature: `deploy_hook`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Ansible Role to configure Certbot (for Let's Encrypt)
 | certbot_key_type:           | no          | string | "ecdsa"          | The protocol used for the key, can be `"ecdsa"` or `"rsa"`.|
 | certbot_key_curve:          | no          | string | secp384r1        | The curve that should be used for the key, only active when `certbot_key_type:` is `"rsa"`. The following curves are allowed: `"secp256r1"`, `"secp384r1"`, `"secp521r1"`. **NOTE**: that Let's Encrypt only supports `"secp384r1"`, This will be enforced when `server:` is empty.|
 | certbot_key_size:           | no          | int    | 4096             | The size of the key, only active when `certbot_key_type:` is `"rsa"`. The following sizes are allowed: `2048`, `3072`, `4096`|
-| certbot_pre_hook:           | no          | string | ""               | The command to be run before requesting the certificate. The command will be encapsulated in `''`.|
-| certbot_post_hook:          | no          | string | ""               | The command to be run before requesting the certificate. The command will be encapsulated in `''`.|
+| certbot_pre_hook:           | no          | string | ""               | The command to be run before requesting/renewing the certificate. The command will be encapsulated in `''`.|
+| certbot_post_hook:          | no          | string | ""               | The command to be run after requesting/renewing the certificate. The command will be encapsulated in `''`.|
 | certbot_test:               | no          | bool   | false            | When `true` a test certificate will be requested.|
 | certbot_ca:                 | no          | string | ""               | Path to the CA to use for request validation, should be used in tandem with `certbot_server:`.|
 | certbot_server:             | no          | string | ""               | Url for a custom ACME server, should be used in tandem with `certbot_ca`.|

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Ansible Role to configure Certbot (for Let's Encrypt)
 | certbot_key_size:           | no          | int    | 4096             | The size of the key, only active when `certbot_key_type:` is `"rsa"`. The following sizes are allowed: `2048`, `3072`, `4096`|
 | certbot_pre_hook:           | no          | string | ""               | The command to be run before requesting/renewing the certificate. The command will be encapsulated in `''`.|
 | certbot_post_hook:          | no          | string | ""               | The command to be run after requesting/renewing the certificate. The command will be encapsulated in `''`.|
+| certbot_deploy_hook:        | no          | string | ""               | The command to be run when a certificate was successfully requested/renewed. The command will be encapsulated in `''`.|
 | certbot_test:               | no          | bool   | false            | When `true` a test certificate will be requested.|
 | certbot_ca:                 | no          | string | ""               | Path to the CA to use for request validation, should be used in tandem with `certbot_server:`.|
 | certbot_server:             | no          | string | ""               | Url for a custom ACME server, should be used in tandem with `certbot_ca`.|
@@ -55,6 +56,7 @@ When any of the following setting change in the global or per cert config a new 
 | key_size:           | no          | int     | `certbot_key_size:`           | Same as `certbot_key_size:`.|
 | pre_hook:           | no          | string  | `certbot_pre_hook`            | Same as `certbot_pre_hook:`.|
 | post_hook:          | no          | string  | `certbot_post_hook`           | Same as `certbot_post_hook:`.|
+| deploy_hook:        | no          | string  | `certbot_deploy_hook`         | Same as `certbot_deploy_hook:`.|
 | test:               | no          | bool    | `certbot_test:`               | Same as `certbot_test:`.|
 | ca:                 | no          | string  | `certbot_ca:`                 | Same as `certbot_ca:`.|
 | server:             | no          | string  | `certbot_server:`             | Same as `certbot_server:`.|

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@ certbot_agree_tos: false
 certbot_allow_breaking: false
 certbot_ca: ""
 certbot_certs: []
+certbot_deploy_hook: ""
 certbot_email: ""
 certbot_key_curve: secp384r1
 certbot_key_size: 4096
@@ -35,6 +36,8 @@ certbot_request_command: >-
     if certbot_used_pre_hook != '' else '' }}
   {{ "--post-hook '" + certbot_used_post_hook + "'"
     if certbot_used_post_hook != '' else '' }}
+  {{ "--deploy-hook '" + certbot_used_deploy_hook + "'"
+    if certbot_used_deploy_hook != '' else '' }}
 
 certbot_remove_command: >-
   {{ certbot_script }} delete --non-interactive --cert-name {{ item }}

--- a/tasks/present.ansible.yml
+++ b/tasks/present.ansible.yml
@@ -58,6 +58,19 @@
     loop_var: cert_item
     label: "{{ cert_item.primary_domain }}"
 
+- name: Update deploy hook for existing certificates
+  ansible.builtin.lineinfile:
+    path: "/etc/letsencrypt/renewal/{{ cert_item.primary_domain }}.conf"
+    regexp: "{{ certbot_regex_deploy_hook }}"
+    line: "deploy_hook = '{{ certbot_used_deploy_hook }}'"
+    insertafter: "[renewalparams]"
+    state: >-
+      {{ (certbot_used_deploy_hook != '') | ternary('present', 'absent') }}
+  with_items: "{{ certbot_list_certs_present_existing }}"
+  loop_control:
+    loop_var: cert_item
+    label: "{{ cert_item.primary_domain }}"
+
 - name: Request certificates
   ansible.builtin.include_tasks:
     file: request-cert.ansible.yml
@@ -89,6 +102,19 @@
     insertafter: "[renewalparams]"
     state: >-
       {{ (certbot_used_post_hook != '') | ternary('present', 'absent') }}
+  with_items: "{{ certbot_list_certs_present_not_existing }}"
+  loop_control:
+    loop_var: cert_item
+    label: "{{ cert_item.primary_domain }}"
+
+- name: Update deploy hook for new certificates
+  ansible.builtin.lineinfile:
+    path: "/etc/letsencrypt/renewal/{{ cert_item.primary_domain }}.conf"
+    regexp: "{{ certbot_regex_deploy_hook }}"
+    line: "deploy_hook = '{{ certbot_used_deploy_hook }}'"
+    insertafter: "[renewalparams]"
+    state: >-
+      {{ (certbot_used_deploy_hook != '') | ternary('present', 'absent') }}
   with_items: "{{ certbot_list_certs_present_not_existing }}"
   loop_control:
     loop_var: cert_item

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,6 +1,8 @@
 ---
 certbot_used_allow_breaking: >-
   {{ cert_item.allow_breaking | default(certbot_allow_breaking) }}
+certbot_used_deploy_hook: >-
+  {{ cert_item.deploy_hook | default(certbot_deploy_hook) }}
 certbot_used_email: "{{ cert_item.email | default(certbot_email) }}"
 certbot_used_ca: "{{ cert_item.ca | default(certbot_ca) }}"
 certbot_used_key_curve: "{{ cert_item.key_curve | default(certbot_key_curve) }}"
@@ -28,6 +30,7 @@ certbot_valid_key_type:
   - rsa
   - ecdsa
 
+certbot_regex_deploy_hook: "^#?\\s*deploy_hook\\s*=.*$"
 certbot_regex_pre_hook: "^#?\\s*pre_hook\\s*=.*$"
 certbot_regex_post_hook: "^#?\\s*post_hook\\s*=.*$"
 


### PR DESCRIPTION
Fixed the docs for the `certbot_pre_hook` and `certbot_post_hook`.
Made `--deploy-hook` configurable.