### PR TITLE
Purge apt package when absent

### DIFF
--- a/tasks/absent.ansible.yml
+++ b/tasks/absent.ansible.yml
@@ -6,3 +6,4 @@
       - python3-certbot-nginx
       - python3-certbot-apache
     state: absent
+    purge: true


### PR DESCRIPTION
With this change, you can easily and quickly change the CA you are currently using by setting `certbot_state: absent`
and `nginx_state: absent`, running your ansible pipeline, then removing those lines and running the pipeline again.