### PR TITLE
refactor: obtaining certificate info

### DIFF
--- a/tasks/check-cert.ansible.yml
+++ b/tasks/check-cert.ansible.yml
@@ -1,18 +1,25 @@
 ---
 - name: Read certificate's contents from remote machine
   ansible.builtin.slurp:
-    src: "{{ fullchain_item }}"
+    src: "{{ item }}"
+  with_items: "{{ certbot_available_certs_paths }}"
+  loop_control:
+    # `/fullchain.pem` is the 14
+    label: "{{ (item[:-14] | split('/'))[-1] }}"
   register: certbot_certificate_content
 
 - name: Get certificate properties
   community.crypto.x509_certificate_info:
-    content: "{{ certbot_certificate_content.content | b64decode }}"
-  register: certbot_crt_info
+    content: "{{ item.content | b64decode }}"
+  loop: "{{ certbot_certificate_content.results }}"
+  loop_control:
+    # `/fullchain.pem` is the 14
+    label: "{{ (item.item[:-14] | split('/'))[-1] }}"
   delegate_to: localhost
   become: false
+  register: certbot_crt_info
 
 - name: Build certificate list
   ansible.builtin.set_fact:
     certbot_certs_properties: >-
-      {{ certbot_certs_properties +
-      [{'domain': fullchain_item.split('/')[4], 'crt': certbot_crt_info}] }}
+      {{ lookup('template', 'build-certificate-list.yml.j2') | from_yaml }}

--- a/tasks/present.ansible.yml
+++ b/tasks/present.ansible.yml
@@ -20,11 +20,11 @@
 - name: Get certificate properties
   ansible.builtin.include_tasks:
     file: check-cert.ansible.yml
-  with_items: >-
-    {{ certbot_available_certs.stdout |
-    regex_findall('Certificate Path: (.+[^\n])') | list }}
-  loop_control:
-    loop_var: fullchain_item
+  vars:
+    certbot_available_certs_paths: >-
+      {{ certbot_available_certs.stdout
+      | regex_findall('Certificate Path: (.+[^\n])') | list }}
+  when: certbot_available_certs_paths | length() > 0
 
 - name: Remove certificates
   ansible.builtin.command:

--- a/templates/build-certificate-list.yml.j2
+++ b/templates/build-certificate-list.yml.j2
@@ -1,0 +1,4 @@
+{% for item in certbot_crt_info.results %}
+- domain: {{ item.subject.commonName }}
+  crt: {{ item }}
+{% endfor %}


### PR DESCRIPTION
Optimized the logic for obtaining certificate information to be separate loops instead of one long loop.

Was able to eliminate the `set_fact` loop from the Ansible log entirely.