### PR TITLE
Refactor: hooks

### DIFF
--- a/tasks/present.ansible.yml
+++ b/tasks/present.ansible.yml
@@ -36,7 +36,7 @@
   ansible.builtin.lineinfile:
     path: "/etc/letsencrypt/renewal/{{ cert_item.primary_domain }}.conf"
     regexp: "{{ certbot_regex_pre_hook }}"
-    line: "pre_hook = '{{ certbot_used_pre_hook }}'"
+    line: "pre_hook = {{ certbot_used_pre_hook }}"
     insertafter: "[renewalparams]"
     state: >-
       {{ (certbot_used_pre_hook != '') | ternary('present', 'absent') }}
@@ -49,7 +49,7 @@
   ansible.builtin.lineinfile:
     path: "/etc/letsencrypt/renewal/{{ cert_item.primary_domain }}.conf"
     regexp: "{{ certbot_regex_post_hook }}"
-    line: "post_hook = '{{ certbot_used_post_hook }}'"
+    line: "post_hook = {{ certbot_used_post_hook }}"
     insertafter: "[renewalparams]"
     state: >-
       {{ (certbot_used_post_hook != '') | ternary('present', 'absent') }}
@@ -62,7 +62,7 @@
   ansible.builtin.lineinfile:
     path: "/etc/letsencrypt/renewal/{{ cert_item.primary_domain }}.conf"
     regexp: "{{ certbot_regex_deploy_hook }}"
-    line: "deploy_hook = '{{ certbot_used_deploy_hook }}'"
+    line: "deploy_hook = {{ certbot_used_deploy_hook }}"
     insertafter: "[renewalparams]"
     state: >-
       {{ (certbot_used_deploy_hook != '') | ternary('present', 'absent') }}

--- a/tasks/present.ansible.yml
+++ b/tasks/present.ansible.yml
@@ -81,45 +81,6 @@
   when: certbot_con_diff
     and not certbot_con_cert_item_absent
 
-- name: Update pre hook for new certificates
-  ansible.builtin.lineinfile:
-    path: "/etc/letsencrypt/renewal/{{ cert_item.primary_domain }}.conf"
-    regexp: "{{ certbot_regex_pre_hook }}"
-    line: "pre_hook = '{{ certbot_used_pre_hook }}'"
-    insertafter: "[renewalparams]"
-    state: >-
-      {{ (certbot_used_pre_hook != '') | ternary('present', 'absent') }}
-  with_items: "{{ certbot_list_certs_present_not_existing }}"
-  loop_control:
-    loop_var: cert_item
-    label: "{{ cert_item.primary_domain }}"
-
-- name: Update post hook for new certificates
-  ansible.builtin.lineinfile:
-    path: "/etc/letsencrypt/renewal/{{ cert_item.primary_domain }}.conf"
-    regexp: "{{ certbot_regex_post_hook }}"
-    line: "post_hook = '{{ certbot_used_post_hook }}'"
-    insertafter: "[renewalparams]"
-    state: >-
-      {{ (certbot_used_post_hook != '') | ternary('present', 'absent') }}
-  with_items: "{{ certbot_list_certs_present_not_existing }}"
-  loop_control:
-    loop_var: cert_item
-    label: "{{ cert_item.primary_domain }}"
-
-- name: Update deploy hook for new certificates
-  ansible.builtin.lineinfile:
-    path: "/etc/letsencrypt/renewal/{{ cert_item.primary_domain }}.conf"
-    regexp: "{{ certbot_regex_deploy_hook }}"
-    line: "deploy_hook = '{{ certbot_used_deploy_hook }}'"
-    insertafter: "[renewalparams]"
-    state: >-
-      {{ (certbot_used_deploy_hook != '') | ternary('present', 'absent') }}
-  with_items: "{{ certbot_list_certs_present_not_existing }}"
-  loop_control:
-    loop_var: cert_item
-    label: "{{ cert_item.primary_domain }}"
-
 - name: Update renew_before_expiry in letsencrypt renewal configuration
   ansible.builtin.lineinfile:
     path: "/etc/letsencrypt/renewal/{{ cert_item.primary_domain }}.conf"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -132,12 +132,6 @@ certbot_list_certs_present_existing: >-
   | selectattr('primary_domain', 'in',
     certbot_certs_properties | map(attribute='domain') | list) | list}}
 
-# return a list of certbot_certs objects the certificates where state: is undefined or 'present' and the primary_domain is not in the list of installed certificates
-certbot_list_certs_present_not_existing: >-
-  {{ certbot_list_certs_present
-  | rejectattr('primary_domain', 'in',
-    certbot_certs_properties | map(attribute='domain') | list) | list}}
-
 # returns a list of domains that are installed
 certbot_list_certs_installed: >-
   {{ (certbot_certs_properties | map(attribute='domain'))


### PR DESCRIPTION
Removed updating the hooks for new certs, as for new certs the hooks are already set by `certbot_request_command`.

Certbot doesn't encapsulate hooks in the config when set on the command line.
We shouldn't encapsulate them either as it leads to change noise and more importantly can make scripts run differently during create and refresh.
