### PR TITLE
Fix: RSA cannot concat str and int

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,7 +30,8 @@ certbot_request_command: >-
   {{ ('--server ' + certbot_used_server) if certbot_used_server else '' }}
   --key-type {{ certbot_used_key_type }}
   {{ '--elliptic-curve ' + certbot_used_key_curve if certbot_is_ecdsa else '' }}
-  {{ '--rsa-key-size ' + certbot_used_key_size if certbot_is_rsa else '' }}
+  {{ '--rsa-key-size ' + certbot_used_key_size | string
+    if certbot_is_rsa else '' }}
   {{ '--break-my-certs' if certbot_used_allow_breaking }}
   {{ "--pre-hook '" + certbot_used_pre_hook + "'"
     if certbot_used_pre_hook != '' else '' }}

--- a/tasks/assert.ansible.yml
+++ b/tasks/assert.ansible.yml
@@ -4,8 +4,7 @@
   block:
     - name: Assert primary_domain is not empty
       ansible.builtin.assert:
-        that: >-
-          {{ certbot_primary_domain_list | length == certbot_certs | length }}
+        that: certbot_primary_domain_list | length == certbot_certs | length
       vars:
         certbot_primary_domain_list: >-
           {{ certbot_certs | selectattr('primary_domain', 'defined') |
@@ -116,8 +115,7 @@
   block:
     - name: Assert key_size is valid
       ansible.builtin.assert:
-        that: >-
-          {{ certbot_used_key_size | int in certbot_valid_key_size }}
+        that: certbot_used_key_size | int in certbot_valid_key_size
       with_items: "{{ certbot_certs }}"
       loop_control:
         loop_var: cert_item


### PR DESCRIPTION
Fixed and issue where we couldn't concatenate the `certbot_key_size:` due to `cannot concat str and int`.
Fixed 2 more Ansible 2.24 deprecation warnings.