### PR TITLE
feat: Request new cert on `ca` and  `server` change

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,4 @@
 ---
 skip_list:
+  - ignore-errors
   - role-name

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,14 @@ name: CI
       - '*.md'
       - '.gitignore'
 
-defaults:
-  run:
-    working-directory: 'tinyblargon.certbot'
-
 jobs:
 
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tinyblargon.certbot
     steps:
       - name: Check out the codebase.
         uses: actions/checkout@v5
@@ -34,5 +33,27 @@ jobs:
 
       - name: Install test dependencies.
         run: pip3 install ansible ansible-lint
+      - name: Log tool info
+        run: make ansible_lint_info
       - name: Lint code.
-        run: ansible-lint
+        run: make lint
+
+  unit-tests:
+    name: Unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v5
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies.
+        run: pip3 install ansible
+      - name: Log tool info
+        run: make ansible_info
+      - name: Run unit test playbook.
+        run: make unit_test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+
+.PHONY: all
+all:
+
+.PHONY: info
+info: ansible_info ansible_lint_info
+
+.PHONY: lint
+lint:
+	@ansible-lint
+
+.PHONY: unit_test
+unit_test:
+	@export ANSIBLE_ROLES_PATH="$$(dirname "$$(pwd)")" ;\
+		export ANSIBLE_FORCE_COLOR=True ;\
+		ansible-playbook unit-tests.playbook.yml
+
+.PHONY: ansible_info
+ansible_info:
+	@ansible --version
+
+.PHONY: ansible_lint_info
+ansible_lint_info:
+	@ansible-lint --version

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ When any of the following setting change in the global or per cert config a new 
 - `key_curve:`
 - `key_size:`
 - `test:`
+- `ca:`
+- `server:`
 
 | **Variable Name**   | **Required**| **Type**| **Default Value**             | **Description**
 | :-------------------| :----------:| :------:| :----------------------------:| :--------------

--- a/tasks/check-cert.ansible.yml
+++ b/tasks/check-cert.ansible.yml
@@ -10,11 +10,11 @@
 
 - name: Get certificate properties
   community.crypto.x509_certificate_info:
-    content: "{{ item.content | b64decode }}"
+    content: "{{ fullchain_item.content | b64decode }}"
   loop: "{{ certbot_certificate_content.results }}"
   loop_control:
-    # `/fullchain.pem` is the 14
-    label: "{{ (item.item[:-14] | split('/'))[-1] }}"
+    loop_var: fullchain_item
+    label: "{{ certbot_fullchain_domain }}"
   delegate_to: localhost
   become: false
   register: certbot_crt_info
@@ -23,3 +23,36 @@
   ansible.builtin.set_fact:
     certbot_certs_properties: >-
       {{ lookup('template', 'build-certificate-list.yml.j2') | from_yaml }}
+
+- name: Check root CA
+  community.crypto.certificate_complete_chain:
+    input_chain: "{{ fullchain_item.content | b64decode }}"
+    root_certificates: >-
+      {{ certbot_certs
+        | selectattr('primary_domain', 'equalto', certbot_fullchain_domain)
+        | selectattr('ca', 'defined')
+        | map(attribute='ca') | default([certbot_ca],true) }}
+  loop: "{{ certbot_certificate_content.results }}"
+  loop_control:
+    loop_var: fullchain_item
+    label: "{{ certbot_fullchain_domain }}"
+  become: false
+  failed_when: false
+  when: >-
+    certbot_fullchain_domain
+    in certbot_list_certs_present_existing_ca
+  register: certbot_ctr_root
+
+- name: Read remewal config
+  ansible.builtin.slurp:
+    src: "/etc/letsencrypt/renewal/{{ item.domain }}.conf"
+  loop: "{{ certbot_certs_properties }}"
+  loop_control:
+    label: "{{ item.domain }}"
+  when: item.domain in certbot_list_certs_present_existing_primary_domain
+  register: certbot_renewal_file_raw
+
+- name: Build root CA table
+  ansible.builtin.set_fact:
+    certbot_certs_root_ca: "{{ certbot_build_certs_root_ca }}"
+    certbot_certs_renewal: "{{ certbot_build_certs_renewal }}"

--- a/tasks/request-cert.ansible.yml
+++ b/tasks/request-cert.ansible.yml
@@ -10,8 +10,12 @@
       no_log: true
   rescue:
     - name: Display error message
-      ansible.builtin.fail:
+      # we use this instead of ansible.builtin.fail as it allow for better formatting
+      ansible.builtin.debug:
         msg: >-
           {{ 'for replacing producton certificates with staging ones certbot_allow_breaking should be set to true'
           if '--break-my-certs' in ansible_failed_result.stderr
-          else ansible_failed_result.stderr }}
+          else 'to use letsencrypt you must agree to their Terms of Service, set `certbot_agree_tos:` to `true` to agree'
+          if '--agree-tos' in ansible_failed_result.stderr
+          else (ansible_failed_result.stderr_lines) }}
+      failed_when: true

--- a/tasks/unit-tests/certbot_build_certs_root_ca.ansible.yml
+++ b/tasks/unit-tests/certbot_build_certs_root_ca.ansible.yml
@@ -1,0 +1,64 @@
+---
+- name: Test certbot_build_certs_root_ca
+  ansible.builtin.assert:
+    that: certbot_build_certs_root_ca == test_item.output
+    fail_msg: >-
+      {{ 'Test: ' + test_item.name + ', Expected: ' + test_item.output | string
+      + ' , but got: ' + certbot_build_certs_root_ca | string }}
+  loop:
+    - name: all match ca
+      output: []
+      input:
+        - fullchain_item:
+            source: "/etc/letsencrypt/live/1.example.com/fullchain.pem"
+          root: "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"
+          skipped: false
+        - fullchain_item:
+            source: "/etc/letsencrypt/live/2.example.com/fullchain.pem"
+          root: "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"
+        - fullchain_item:
+            source: "/etc/letsencrypt/live/3.example.com/fullchain.pem"
+          root: "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"
+    - name: all don't match ca
+      output:
+        - 1.example.com
+        - 2.example.com
+        - 3.example.com
+      input:
+        - fullchain_item:
+            source: "/etc/letsencrypt/live/1.example.com/fullchain.pem"
+        - fullchain_item:
+            source: "/etc/letsencrypt/live/2.example.com/fullchain.pem"
+          skipped: false
+        - fullchain_item:
+            source: "/etc/letsencrypt/live/3.example.com/fullchain.pem"
+    - name: some don't match ca
+      output: [2.example.com]
+      input:
+        - fullchain_item:
+            source: "/etc/letsencrypt/live/1.example.com/fullchain.pem"
+          root: "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"
+          skipped: false
+        - fullchain_item:
+            source: "/etc/letsencrypt/live/2.example.com/fullchain.pem"
+        - fullchain_item:
+            source: "/etc/letsencrypt/live/3.example.com/fullchain.pem"
+          root: "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"
+    - name: one skipped
+      output: []
+      input:
+        - fullchain_item:
+            source: "/etc/letsencrypt/live/1.example.com/fullchain.pem"
+          root: "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"
+        - fullchain_item:
+            source: "/etc/letsencrypt/live/2.example.com/fullchain.pem"
+          skipped: true
+        - fullchain_item:
+            source: "/etc/letsencrypt/live/3.example.com/fullchain.pem"
+          root: "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n"
+  loop_control:
+    loop_var: test_item
+  vars:
+    certbot_ctr_root:
+      results: "{{ test_item.input }}"
+  ignore_errors: "{{ certbot_ci_ignore }}"

--- a/tasks/unit-tests/certbot_con_different_server.ansible.yml
+++ b/tasks/unit-tests/certbot_con_different_server.ansible.yml
@@ -1,0 +1,75 @@
+---
+- name: Test certbot_con_different_server
+  ansible.builtin.assert:
+    that: certbot_con_different_server == test_item.output
+    fail_msg: >-
+      {{ 'Test: ' + test_item.name + ', Expected: ' + test_item.output | string
+      + ' , but got: ' + certbot_con_different_server | string }}
+  loop:
+    - name: letsencrypt
+      output: false
+      input:
+        cert_item:
+          primary_domain: 1.example.com
+        certbot_certs_renewal:
+          - domain: 1.example.com
+            renewal:
+              server: https://acme-v02.api.letsencrypt.org/directory
+        certbot_server: ""
+    - name: same global
+      output: false
+      input:
+        cert_item:
+          primary_domain: 1.example.com
+        certbot_certs_renewal:
+          - domain: 1.example.com
+            renewal:
+              server: https://ca.example.com/acme/acme/directory
+        certbot_server: https://ca.example.com/acme/acme/directory
+    - name: different global
+      output: true
+      input:
+        cert_item:
+          primary_domain: 1.example.com
+        certbot_certs_renewal:
+          - domain: 1.example.com
+            renewal:
+              server: https://ca.test.com/acme/acme/directory
+        certbot_server: https://ca.example.com/acme/acme/directory
+    - name: private to letsencrypt
+      output: true
+      input:
+        cert_item:
+          primary_domain: 1.example.com
+        certbot_certs_renewal:
+          - domain: 1.example.com
+            renewal:
+              server: https://ca.test.com/acme/acme/directory
+        certbot_server: ""
+    - name: letsencrypt to private
+      output: true
+      input:
+        cert_item:
+          primary_domain: 1.example.com
+        certbot_certs_renewal:
+          - domain: 1.example.com
+            renewal:
+              server: https://acme-v02.api.letsencrypt.org/directory
+        certbot_server: https://ca.example.com/acme/acme/directory
+    - name: primary_domain not in list, should never happen in the real world
+      output: false
+      input:
+        cert_item:
+          primary_domain: 2.example.com
+        certbot_certs_renewal:
+          - domain: 1.example.com
+            renewal:
+              server: https://acme-v02.api.letsencrypt.org/directory
+        certbot_server: https://ca.example.com/acme/acme/directory
+  loop_control:
+    loop_var: test_item
+  vars:
+    certbot_server: "{{ test_item.input.certbot_server }}"
+    cert_item: "{{ test_item.input.cert_item }}"
+    certbot_certs_renewal: "{{ test_item.input.certbot_certs_renewal }}"
+  ignore_errors: "{{ certbot_ci_ignore }}"

--- a/tasks/unit-tests/main.ansible.yml
+++ b/tasks/unit-tests/main.ansible.yml
@@ -1,0 +1,8 @@
+---
+- name: Test certbot_build_certs_root_ca
+  ansible.builtin.import_tasks:
+    file: unit-tests/certbot_build_certs_root_ca.ansible.yml
+
+- name: Test certbot_con_different_server
+  ansible.builtin.import_tasks:
+    file: unit-tests/certbot_con_different_server.ansible.yml

--- a/templates/build-certs-renewal.yml.j2
+++ b/templates/build-certs-renewal.yml.j2
@@ -1,0 +1,9 @@
+{% for item in certbot_renewal_file_raw.results %}
+- domain: {{ item.item.domain }}
+  renewal:
+{% for renewal_item in item.content | b64decode | split('\n') %}
+{% if renewal_item | length() > 0 and renewal_item[0] != '#' and ' = ' in renewal_item%}
+    {{ (renewal_item | regex_search('^(.+)\\s*=\\s*', '\\1'))[0] }}: {{ (renewal_item | regex_search('.+\\s*=\\s*(.+)$', '\\1'))[0] }}
+{% endif %}
+{% endfor %}
+{% endfor %}

--- a/templates/build-root-ca-table.yml.j2
+++ b/templates/build-root-ca-table.yml.j2
@@ -1,0 +1,5 @@
+{% for item in certbot_ctr_root.results %}
+{% if item.root is undefined and (item.skipped is undefined or not item.skipped)%}
+- {{ (item.fullchain_item.source[:-14] | split('/'))[-1] }}
+{% endif %}
+{% endfor %}

--- a/unit-tests.playbook.yml
+++ b/unit-tests.playbook.yml
@@ -1,0 +1,11 @@
+---
+- name: Run unit tests
+  hosts: localhost
+  gather_facts: false
+  vars:
+    certbot_ci_ignore: false
+  tasks:
+    - name: Run unit tests
+      ansible.builtin.include_role:
+        name: ansible-role-certbot
+        tasks_from: unit-tests/main.ansible.yml

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -35,6 +35,8 @@ certbot_regex_pre_hook: "^#?\\s*pre_hook\\s*=.*$"
 certbot_regex_post_hook: "^#?\\s*post_hook\\s*=.*$"
 
 certbot_certs_properties: []
+certbot_certs_renewal: []
+certbot_certs_root_ca: []
 
 certbot_is_ecdsa: "{{ certbot_used_key_type in ['ecc', 'ecdsa'] }}"
 certbot_is_rsa: "{{ certbot_used_key_type == 'rsa' }}"
@@ -44,12 +46,14 @@ certbot_select_cert: >-
   {{ certbot_certs_properties |
   selectattr('domain', 'equalto', cert_item.primary_domain) }}
 
-# This condition determens if the certificates are the same
+# This condition determens if the certificates are different
 certbot_con_diff: >-
   {{ certbot_select_cert | length == 0
   or certbot_con_diff_domains
   or not certbot_con_same_mode
-  or not certbot_con_same_key }}
+  or not certbot_con_same_key
+  or certbot_con_different_ca
+  or certbot_con_different_server }}
 
 certbot_con_diff_domains: >-
   {{ (certbot_current_domains | difference(certbot_cert_domains) | length > 0)
@@ -98,8 +102,28 @@ certbot_con_same_key_curve: >-
   {{ certbot_select_cert.0.crt.public_key_data.curve is defined
   and certbot_select_cert.0.crt.public_key_data.curve == certbot_used_key_curve }}
 
+# returns true if we are sure the certificate doesn't belong to the specified rootCA
+certbot_con_different_ca: >-
+  {{ cert_item.primary_domain in certbot_certs_root_ca }}
+
 certbot_con_cert_item_absent: >-
   {{ cert_item.state is defined and cert_item.state == 'absent' }}
+
+certbot_con_different_server: >-
+  {{ false if certbot_used_server == ""
+    and (((certbot_certs_renewal_select_server
+      | regex_search('^https://.+(\.letsencrypt\.org)/.*', '\1')
+      | default([''], true))[0]) == '.letsencrypt.org')
+    else (
+      certbot_used_server != certbot_certs_renewal_select_server
+    )
+    }}
+
+certbot_certs_renewal_select_server: >-
+  {{ ((certbot_certs_renewal
+      | selectattr('domain', 'equalto', cert_item.primary_domain))[0]
+      | default({'renewal':{'server':certbot_used_server}}, true)
+      ).renewal.server }}
 
 # list of certificate names to remove
 certbot_remove_certs: >-
@@ -132,6 +156,22 @@ certbot_list_certs_present_existing: >-
   | selectattr('primary_domain', 'in',
     certbot_certs_properties | map(attribute='domain') | list) | list}}
 
+certbot_list_certs_present_existing_ca: >-
+  {{ ((certbot_list_certs_present_existing
+    | selectattr('ca', 'defined')
+    | selectattr('ca', '!=', '') | list)
+    + ((
+      certbot_list_certs_present_existing
+      | selectattr('ca', 'undefined'))
+      if certbot_ca != '' else []
+    ))
+    | map(attribute='primary_domain') | list }}
+
+# returns primary_domain: certbot_list_certs_present_existing:
+certbot_list_certs_present_existing_primary_domain: >-
+  {{ certbot_list_certs_present_existing
+    | map(attribute='primary_domain') | list }}
+
 # returns a list of domains that are installed
 certbot_list_certs_installed: >-
   {{ (certbot_certs_properties | map(attribute='domain'))
@@ -148,3 +188,15 @@ certbot_failed_domains: >-
   {{ ansible_failed_result.results | selectattr('failed', 'defined') |
   selectattr('failed', 'equalto', true) | map(attribute='_ansible_item_label') |
   list }}
+
+# Parses the primary domain name from the fullchain file
+# `/fullchain.pem` is the 14
+certbot_fullchain_domain: "{{ (fullchain_item.source[:-14] | split('/'))[-1] }}"
+
+certbot_build_certs_root_ca: >-
+  {{ (lookup('template', 'build-root-ca-table.yml.j2') | from_yaml)
+    | default([], true) }}
+
+certbot_build_certs_renewal: >-
+  {{ (lookup('template', 'build-certs-renewal.yml.j2') | from_yaml)
+    | default([], true) }}


### PR DESCRIPTION
When the `ca` or `server` setting changes for a certificate a new one will be requests.
This helps with RootCA migrations and CA server migrations for example: LetsEncrypt to Step-CA.