### PR TITLE
Fix: primary domain

### DIFF
--- a/tasks/check-cert.ansible.yml
+++ b/tasks/check-cert.ansible.yml
@@ -4,8 +4,7 @@
     src: "{{ item }}"
   with_items: "{{ certbot_available_certs_paths }}"
   loop_control:
-    # `/fullchain.pem` is the 14
-    label: "{{ (item[:-14] | split('/'))[-1] }}"
+    label: "{{ item | dirname() | basename() }}"
   register: certbot_certificate_content
 
 - name: Get certificate properties

--- a/tasks/check-cert.ansible.yml
+++ b/tasks/check-cert.ansible.yml
@@ -20,8 +20,7 @@
 
 - name: Build certificate list
   ansible.builtin.set_fact:
-    certbot_certs_properties: >-
-      {{ lookup('template', 'build-certificate-list.yml.j2') | from_yaml }}
+    certbot_certs_properties: "{{ certbot_build_certificate_list }}"
 
 - name: Check root CA
   community.crypto.certificate_complete_chain:

--- a/tasks/unit-tests/certbot_build_certificate_list.ansible.yml
+++ b/tasks/unit-tests/certbot_build_certificate_list.ansible.yml
@@ -1,0 +1,39 @@
+---
+- name: Test certbot_build_certificate_list
+  ansible.builtin.assert:
+    that: certbot_build_certificate_list == test_item.output
+    fail_msg: >-
+      {{ 'Test: ' + test_item.name + ', Expected: ' + test_item.output | string
+      + ' , but got: ' + certbot_build_certificate_list | string }}
+  loop:
+    - name: test
+      input:
+        - fullchain_item:
+            source: /etc/letsencrypt/live/example.com/fullchain.pem
+          subject_alt_name:
+            - DNS:example.com
+        - fullchain_item:
+            source: /etc/letsencrypt/live/test.example.com/fullchain.pem
+          subject_alt_name:
+            - DNS:example.com
+            - DNS:test.example.com
+      output:
+        - domain: example.com
+          crt:
+            fullchain_item:
+              source: /etc/letsencrypt/live/example.com/fullchain.pem
+            subject_alt_name:
+              - DNS:example.com
+        - domain: test.example.com
+          crt:
+            fullchain_item:
+              source: /etc/letsencrypt/live/test.example.com/fullchain.pem
+            subject_alt_name:
+              - DNS:example.com
+              - DNS:test.example.com
+  loop_control:
+    loop_var: test_item
+  vars:
+    certbot_crt_info:
+      results: "{{ test_item.input }}"
+  ignore_errors: "{{ certbot_ci_ignore }}"

--- a/tasks/unit-tests/main.ansible.yml
+++ b/tasks/unit-tests/main.ansible.yml
@@ -1,4 +1,8 @@
 ---
+- name: Test certbot_build_certificate_list
+  ansible.builtin.import_tasks:
+    file: unit-tests/certbot_build_certificate_list.ansible.yml
+
 - name: Test certbot_build_certs_root_ca
   ansible.builtin.import_tasks:
     file: unit-tests/certbot_build_certs_root_ca.ansible.yml

--- a/templates/build-certificate-list.yml.j2
+++ b/templates/build-certificate-list.yml.j2
@@ -1,4 +1,4 @@
 {% for item in certbot_crt_info.results %}
-- domain: {{ item.subject.commonName }}
+- domain: {{ item.fullchain_item.source | dirname() | basename() }}
   crt: {{ item }}
 {% endfor %}

--- a/templates/build-root-ca-table.yml.j2
+++ b/templates/build-root-ca-table.yml.j2
@@ -1,5 +1,5 @@
 {% for item in certbot_ctr_root.results %}
 {% if item.root is undefined and (item.skipped is undefined or not item.skipped)%}
-- {{ (item.fullchain_item.source[:-14] | split('/'))[-1] }}
+- {{ item.fullchain_item.source | dirname() | basename() }}
 {% endif %}
 {% endfor %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -192,6 +192,9 @@ certbot_failed_domains: >-
 # Parses the primary domain name from the fullchain file
 certbot_fullchain_domain: "{{ fullchain_item.source | dirname() | basename() }}"
 
+certbot_build_certificate_list: >-
+  {{ lookup('template', 'build-certificate-list.yml.j2') | from_yaml }}
+
 certbot_build_certs_root_ca: >-
   {{ (lookup('template', 'build-root-ca-table.yml.j2') | from_yaml)
     | default([], true) }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -190,8 +190,7 @@ certbot_failed_domains: >-
   list }}
 
 # Parses the primary domain name from the fullchain file
-# `/fullchain.pem` is the 14
-certbot_fullchain_domain: "{{ (fullchain_item.source[:-14] | split('/'))[-1] }}"
+certbot_fullchain_domain: "{{ fullchain_item.source | dirname() | basename() }}"
 
 certbot_build_certs_root_ca: >-
   {{ (lookup('template', 'build-root-ca-table.yml.j2') | from_yaml)


### PR DESCRIPTION
The primary domain was not set correctly in `certbot_certs_properties`, instead an auxiliary one could be set as the primary.
Later code assumed the primary domain would have been set correctly, leading to cascading failures.
Add a new unit test to handle this issue.